### PR TITLE
fix: backup task status reflects real last-run result in WebGUI

### DIFF
--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -320,8 +320,8 @@ func (s *backupService) ExecuteUserBackup(ctx context.Context, uid int64, config
 	if !config.IsEnabled {
 		return code.ErrorBackupConfigDisabled
 	}
-	// Record error
-	// 记录错误
+	// Record error and propagate it back so the API layer can surface failures to the UI
+	// 记录错误并向上抛出，便于 API 层将失败状态展示到 UI（避免弹窗"假成功"）
 	if err := s.handleBackupSync(ctx, config, true); err != nil {
 		// Service shutdown errors bypass finishTask and are not persisted to history
 		if s.ctx.Err() != nil {
@@ -332,6 +332,7 @@ func (s *backupService) ExecuteUserBackup(ctx context.Context, uid int64, config
 			zap.Int64("configID", configID),
 			zap.Error(err),
 		)
+		return err
 	}
 	return nil
 }
@@ -592,19 +593,27 @@ func (s *backupService) runArchive(ctx context.Context, config *domain.BackupCon
 		return count, size, code.ErrorBackupStorageIDInvalid
 	}
 
+	var archiveErrors []string
 	for _, sid := range storageIds {
 		st, err := s.storageService.Get(ctx, uid, sid)
 		if err != nil {
 			s.logger.Warn("Failed to get storage config, skipping", zap.Int64("sid", sid), zap.Error(err))
+			archiveErrors = append(archiveErrors, fmt.Sprintf("storage %d: config error: %v", sid, err))
 			continue
 		}
 		if !st.IsEnabled {
 			s.logger.Info("Storage is disabled, skipping", zap.Int64("sid", sid))
 			continue
 		}
-		s.uploadArchive(ctx, uid, config.ID, st, zipPath, zipName, config.Type, password, startTime, count, size)
+		if err := s.uploadArchive(ctx, uid, config.ID, st, zipPath, zipName, config.Type, password, startTime, count, size); err != nil {
+			s.logger.Warn("Archive upload to storage failed", zap.Int64("sid", sid), zap.String("type", st.Type), zap.Error(err))
+			archiveErrors = append(archiveErrors, fmt.Sprintf("storage %d (%s): %v", sid, st.Type, err))
+		}
 	}
 
+	if len(archiveErrors) > 0 {
+		return count, size, fmt.Errorf("archive errors: %s", strings.Join(archiveErrors, "; "))
+	}
 	return count, size, nil
 }
 
@@ -794,8 +803,11 @@ func (s *backupService) exportArchiveFiles(ctx context.Context, uid, vaultID int
 }
 
 // uploadArchive Upload the archived ZIP file to specified storage target
+// Returns an error if upload (or any preceding step) fails so that callers can
+// aggregate per-storage failures and surface them to the API layer.
 // 将打包好的 ZIP 文件上传到指定的存储目标
-func (s *backupService) uploadArchive(ctx context.Context, uid, configId int64, stDTO *dto.StorageDTO, filePath, fileName, bType, password string, startTime time.Time, count, size int64) {
+// 当上传（或前置步骤）失败时返回 error，便于上层聚合各存储的失败信息并上报到 API 层
+func (s *backupService) uploadArchive(ctx context.Context, uid, configId int64, stDTO *dto.StorageDTO, filePath, fileName, bType, password string, startTime time.Time, count, size int64) error {
 	h := &domain.BackupHistory{
 		UID:       uid,
 		ConfigID:  configId,
@@ -812,29 +824,31 @@ func (s *backupService) uploadArchive(ctx context.Context, uid, configId int64, 
 	h, err := s.backupRepo.CreateHistory(ctx, h, uid)
 	if err != nil {
 		s.logger.Error("Failed to create backup history", zap.Error(err))
-		return
+		return fmt.Errorf("create backup history: %w", err)
 	}
 
 	client, err := s.getStorageClient(ctx, uid, stDTO)
 	if err != nil {
 		s.updateHistory(ctx, h, domain.BackupStatusFailed, err.Error())
-		return
+		return err
 	}
 
 	f, err := os.Open(filePath)
 	if err != nil {
-		s.updateHistory(ctx, h, domain.BackupStatusFailed, fmt.Sprintf("Failed to open backup file: %v", err))
-		return
+		msg := fmt.Sprintf("Failed to open backup file: %v", err)
+		s.updateHistory(ctx, h, domain.BackupStatusFailed, msg)
+		return fmt.Errorf("open backup file: %w", err)
 	}
 	defer f.Close()
 
-	_, err = client.SendFile(fileName, f, "application/zip", startTime)
-	if err != nil {
-		s.updateHistory(ctx, h, domain.BackupStatusFailed, fmt.Sprintf("Upload failed: %v", err))
-		return
+	if _, err := client.SendFile(fileName, f, "application/zip", startTime); err != nil {
+		msg := fmt.Sprintf("Upload failed: %v", err)
+		s.updateHistory(ctx, h, domain.BackupStatusFailed, msg)
+		return fmt.Errorf("upload archive: %w", err)
 	}
 
 	s.updateHistory(ctx, h, domain.BackupStatusSuccess, "Success")
+	return nil
 }
 
 // syncFiles Sync file changes to specified storage target (supports add, modify, delete)

--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -136,9 +136,114 @@ func (s *backupService) GetConfigs(ctx context.Context, uid int64) ([]*dto.Backu
 	}
 	var results []*dto.BackupConfigDTO
 	for _, c := range configs {
+		// Reconcile the last status from the actual last run's history records, so the
+		// API directly reflects the real task result even if the persisted last_status
+		// was written incorrectly by an older version.
+		// 用最近一次运行的历史记录校正 last_status/last_message，让接口直接返回上次
+		// 任务的真实结果，避免旧版本遗留的错误"成功"状态在 UI 上继续显示。
+		s.reconcileLastStatusFromHistory(ctx, c)
 		results = append(results, s.configToDTO(ctx, c))
 	}
 	return results, nil
+}
+
+// reconcileLastStatusFromHistory Corrects a config's persisted last status using the
+// history records of its most recent run. History is written per storage at the actual
+// moment of success/failure, so it is the authoritative record of what really happened.
+// Older versions could persist last_status=Success even when the run failed, and re-running
+// was the only way to repair it. With this correction the configs API always reflects the
+// true result of the last task without requiring a new execution.
+// 用最近一次运行的历史记录校正配置的 last_status。历史记录是按存储逐条写入的真实结果，
+// 比持久化的 last_status 更可信；旧版本可能把失败的运行写成"成功"，本方法可在读取时
+// 直接修正，无需再手动触发一次备份。
+func (s *backupService) reconcileLastStatusFromHistory(ctx context.Context, config *domain.BackupConfig) {
+	if config == nil || config.ID <= 0 || config.LastRunTime.IsZero() {
+		return
+	}
+
+	histories, _, err := s.backupRepo.ListHistory(ctx, config.UID, config.ID, 1, 100)
+	if err != nil || len(histories) == 0 {
+		return
+	}
+
+	// Find the start time of the most recent run that produced history records.
+	// 找出产生过历史记录的最近一次运行的开始时间。
+	latestStart := histories[0].StartTime
+	for _, h := range histories {
+		if h.StartTime.After(latestStart) {
+			latestStart = h.StartTime
+		}
+	}
+
+	// If the most recent history run is older than the recorded last run, the current
+	// run failed before creating any history record, so finishTask's status is authoritative.
+	// 若最新历史运行早于记录的 last_run_time，说明本次运行在产生历史记录前就失败了，
+	// 此时以 finishTask 写入的状态为准，不做覆盖。
+	if latestStart.Before(config.LastRunTime.Add(-time.Second)) {
+		return
+	}
+
+	var runRecords []*domain.BackupHistory
+	for _, h := range histories {
+		if h.StartTime.Equal(latestStart) {
+			runRecords = append(runRecords, h)
+		}
+	}
+	if len(runRecords) == 0 {
+		return
+	}
+
+	status, message := aggregateHistoryRunStatus(runRecords)
+	// Only rewrite when the status itself is wrong. If the status already matches, keep
+	// the existing message written by finishTask, which carries richer context.
+	// 仅当状态本身错误时才覆盖；状态一致时保留 finishTask 写入的、更完整的消息。
+	if status == config.LastStatus {
+		return
+	}
+
+	config.LastStatus = status
+	config.LastMessage = message
+
+	// Best-effort persistence so the database self-heals and stays consistent for every
+	// consumer (e.g. UpdateConfig preserving the corrected value).
+	// 尽力回写数据库完成自愈，保证其它消费方（如 UpdateConfig 保留状态）也能读到正确值。
+	saveCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := s.backupRepo.SaveConfig(saveCtx, config, config.UID); err != nil {
+		s.logger.Warn("Failed to persist reconciled backup config status",
+			zap.Int64("configID", config.ID),
+			zap.Int("status", status),
+			zap.Error(err),
+		)
+	}
+}
+
+// aggregateHistoryRunStatus Derives the aggregate result of one backup run from its
+// per-storage history records, mirroring the priority used by finishTask:
+// stopped > failed > running > no-update > success.
+// 从一次运行的各存储历史记录推导聚合状态，优先级与 finishTask 保持一致。
+func aggregateHistoryRunStatus(records []*domain.BackupHistory) (int, string) {
+	for _, h := range records {
+		if h.Status == domain.BackupStatusStopped {
+			return domain.BackupStatusStopped, "Backup stopped by system"
+		}
+	}
+	for _, h := range records {
+		if h.Status == domain.BackupStatusFailed {
+			return domain.BackupStatusFailed, fmt.Sprintf("Backup failed: %s", h.Message)
+		}
+	}
+	for _, h := range records {
+		if h.Status == domain.BackupStatusRunning {
+			return domain.BackupStatusRunning, h.Message
+		}
+	}
+	for _, h := range records {
+		if h.Status == domain.BackupStatusNoUpdate {
+			return domain.BackupStatusNoUpdate, "Backup success, no updates found"
+		}
+	}
+	return domain.BackupStatusSuccess, "Backup completed successfully"
 }
 
 // UpdateConfig Update or create backup configuration

--- a/internal/service/backup_service_test.go
+++ b/internal/service/backup_service_test.go
@@ -109,6 +109,151 @@ func TestBackupService_GetConfigs_Empty(t *testing.T) {
 	backupRepo.AssertExpectations(t)
 }
 
+// TestBackupService_GetConfigs_ReconcilesStaleSuccess verifies that a stale
+// last_status=Success (e.g. written by an older version that swallowed upload errors)
+// is corrected to Failed from the latest run's history records, and the correction is
+// persisted so the database self-heals.
+// TestBackupService_GetConfigs_ReconcilesStaleSuccess 验证旧的错误"成功"状态会依据最近
+// 一次运行的历史记录被纠正为"失败"，并将纠正结果回写数据库。
+func TestBackupService_GetConfigs_ReconcilesStaleSuccess(t *testing.T) {
+	backupRepo := new(domainmocks.MockBackupRepository)
+	vaultRepo := new(domainmocks.MockVaultRepository)
+	storageSvc := &backupStorageStub{}
+
+	runTime := time.Date(2026, 8, 1, 19, 33, 14, 0, time.Local)
+	configs := []*domain.BackupConfig{
+		{
+			ID:          1,
+			UID:         1,
+			Type:        "full",
+			IsEnabled:   true,
+			LastRunTime: runTime,
+			LastStatus:  domain.BackupStatusSuccess, // stale value written by old version
+			LastMessage: "Backup completed successfully",
+		},
+	}
+	backupRepo.On("ListConfigs", mock.Anything, int64(1)).Return(configs, nil)
+	backupRepo.On("ListHistory", mock.Anything, int64(1), int64(1), int(1), int(100)).Return(
+		[]*domain.BackupHistory{
+			{
+				ID:        2,
+				ConfigID:  1,
+				UID:       1,
+				StorageID: 1,
+				StartTime: runTime,
+				Status:    domain.BackupStatusFailed,
+				Message:   "Invalid R2 AccountID: AccountID is empty.",
+			},
+		}, int64(1), nil,
+	)
+	backupRepo.On("SaveConfig", mock.Anything, mock.MatchedBy(func(c *domain.BackupConfig) bool {
+		return c.ID == 1 && c.LastStatus == domain.BackupStatusFailed &&
+			c.LastMessage == "Backup failed: Invalid R2 AccountID: AccountID is empty."
+	}), int64(1)).Return(configs[0], nil)
+
+	svc := newBackupSvc(backupRepo, vaultRepo, storageSvc)
+	result, err := svc.GetConfigs(context.Background(), 1)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, domain.BackupStatusFailed, result[0].LastStatus)
+	assert.Contains(t, result[0].LastMessage, "Invalid R2 AccountID")
+	backupRepo.AssertExpectations(t)
+}
+
+// TestBackupService_GetConfigs_KeepsEarlyFailure verifies that when the current run
+// failed before creating any history record, the persisted Failed status is kept instead
+// of being overwritten by an older run's history.
+// TestBackupService_GetConfigs_KeepsEarlyFailure 验证本次运行在产生历史记录前失败时，
+// 保留 finishTask 写入的"失败"状态，不会被更早一次运行的历史覆盖。
+func TestBackupService_GetConfigs_KeepsEarlyFailure(t *testing.T) {
+	backupRepo := new(domainmocks.MockBackupRepository)
+	vaultRepo := new(domainmocks.MockVaultRepository)
+	storageSvc := &backupStorageStub{}
+
+	oldRunTime := time.Date(2026, 8, 1, 18, 0, 0, 0, time.Local)
+	currentRunTime := time.Date(2026, 8, 1, 19, 0, 0, 0, time.Local)
+	configs := []*domain.BackupConfig{
+		{
+			ID:          1,
+			UID:         1,
+			Type:        "full",
+			IsEnabled:   true,
+			LastRunTime: currentRunTime,
+			LastStatus:  domain.BackupStatusFailed,
+			LastMessage: "Backup failed: zip failed",
+		},
+	}
+	backupRepo.On("ListConfigs", mock.Anything, int64(1)).Return(configs, nil)
+	backupRepo.On("ListHistory", mock.Anything, int64(1), int64(1), int(1), int(100)).Return(
+		[]*domain.BackupHistory{
+			{
+				ID:        1,
+				ConfigID:  1,
+				UID:       1,
+				StorageID: 1,
+				StartTime: oldRunTime,
+				Status:    domain.BackupStatusSuccess,
+				Message:   "Success",
+			},
+		}, int64(1), nil,
+	)
+
+	svc := newBackupSvc(backupRepo, vaultRepo, storageSvc)
+	result, err := svc.GetConfigs(context.Background(), 1)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, domain.BackupStatusFailed, result[0].LastStatus)
+	assert.Equal(t, "Backup failed: zip failed", result[0].LastMessage)
+	backupRepo.AssertExpectations(t)
+}
+
+// TestBackupService_GetConfigs_NoRewriteWhenConsistent verifies that when the persisted
+// status already matches the latest history run, no correction write is performed.
+// TestBackupService_GetConfigs_NoRewriteWhenConsistent 验证持久化状态与最新历史一致时，
+// 不会执行任何纠正写入。
+func TestBackupService_GetConfigs_NoRewriteWhenConsistent(t *testing.T) {
+	backupRepo := new(domainmocks.MockBackupRepository)
+	vaultRepo := new(domainmocks.MockVaultRepository)
+	storageSvc := &backupStorageStub{}
+
+	runTime := time.Date(2026, 8, 1, 19, 33, 14, 0, time.Local)
+	configs := []*domain.BackupConfig{
+		{
+			ID:          1,
+			UID:         1,
+			Type:        "full",
+			IsEnabled:   true,
+			LastRunTime: runTime,
+			LastStatus:  domain.BackupStatusFailed,
+			LastMessage: "Backup failed: archive errors",
+		},
+	}
+	backupRepo.On("ListConfigs", mock.Anything, int64(1)).Return(configs, nil)
+	backupRepo.On("ListHistory", mock.Anything, int64(1), int64(1), int(1), int(100)).Return(
+		[]*domain.BackupHistory{
+			{
+				ID:        2,
+				ConfigID:  1,
+				UID:       1,
+				StorageID: 1,
+				StartTime: runTime,
+				Status:    domain.BackupStatusFailed,
+				Message:   "archive errors",
+			},
+		}, int64(1), nil,
+	)
+
+	svc := newBackupSvc(backupRepo, vaultRepo, storageSvc)
+	result, err := svc.GetConfigs(context.Background(), 1)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, domain.BackupStatusFailed, result[0].LastStatus)
+	backupRepo.AssertExpectations(t)
+}
+
 // --- UpdateConfig ---
 
 // TestBackupService_UpdateConfig_Success verifies config is saved with resolved vault ID.


### PR DESCRIPTION
## 概述

修复备份任务状态显示错误：

备份失败时 WebGUI 弹窗假报“成功”、任务列表状态徽标显示错误的“成功”，且升级到错误传播修复后，若上次备份任务失败，仍需重新提交一次才会在“备份与同步”页显示“失败”。

本 PR 让执行错误真正向上传播，并让配置列表接口直接读取最近一次运行的历史真实状态，页面加载即可显示真实的“成功 / 失败”，无需再手动触发一次备份。

## 问题描述及原因

### 现象

1. 手动触发备份失败（例如 R2 配置错误）时，WebGUI 弹窗提示“成功”（假成功）。
2. 全量 / 增量备份上传失败时，任务列表的 `last_status` 仍显示“成功”，只有历史记录里能看到 `Failed`。
3. 修复错误传播后仍存在残留问题：如果上次备份任务失败，打开 WebGUI“备份与同步”页仍显示“成功”，必须再手动提交一次才会显示“失败”，而不是直接读取上次任务状态显示成功或失败。

### 根因

- **Bug A（弹窗假成功）**：`ExecuteUserBackup` 中 `handleBackupSync` 返回错误时仅记日志并 `return nil`，错误被吞掉；handler 层永远返回 `Success`，前端只看 `code` 就弹“成功”。
- **Bug B（任务列表状态错误）**：`uploadArchive` 是 void 返回，失败只写历史记录不上抛；`runArchive` 循环也不接收错误，最终 `finishTask` 拿到 `nil` 把 `last_status` 写成“成功”。
- **残留问题（需要重新提交才纠正）**：`backup_config.last_status` 是持久化字段，旧版本错误写成的“成功”在升级后不会自动纠正；WebGUI 徽标直接读取该字段，因此必须等下一次执行（新代码）才会把状态纠正为“失败”。

## 变更内容

- **提交 `cdcd6877`（修复备份执行中的错误传播，确保 API 层能够正确展示失败状态）** — `internal/service/backup_service.go`
  - `ExecuteUserBackup`：`handleBackupSync` 出错时返回错误，不再吞掉（服务关闭场景仍保持原逻辑）。
  - `uploadArchive`：改为返回 `error`，创建历史、获取存储客户端、打开备份文件、上传失败均向上抛出。
  - `runArchive`：循环收集各存储的 `archiveErrors`，任一存储失败即聚合返回错误，`finishTask` 正确写入“失败”，handler 层返回错误码，前端弹窗展示真实失败信息。
- **提交 `77851768`（备份任务列表直接读取上次任务真实状态，避免旧错误状态残留）** — `internal/service/backup_service.go` + `internal/service/backup_service_test.go`
  - `GetConfigs` 新增 `reconcileLastStatusFromHistory`：以 `last_run_time` 匹配 `backup_history` 中最近一次运行的逐存储记录，按“停止 > 失败 > 运行中 > 无更新 > 成功”聚合真实状态；与持久化 `last_status` 不一致时修正返回的 DTO，并尽力回写数据库完成自愈。
  - 边界处理：
    - 本次运行在写入历史记录前就失败（如打包失败）时，保留 `finishTask` 写入的状态，不会被更早运行的历史覆盖；
    - 状态已一致时不触发写入，保留 `finishTask` 写入的更完整错误消息。
  - 新增 3 个单元测试：过期“成功”纠正为“失败”、早期失败不被覆盖、状态一致不重复写库。

## 测试

**自测**：

- `go build ./...` 通过。
- `go test ./internal/service/... ./internal/routers/...` 全部通过（含新增 3 个用例）。

实测：备份失败后正确显示“错误”弹窗和“失败”任务记录。

|        | 外部显示、弹窗                                               | 任务记录显示                                                 |
| ------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
| 修复前 | ![image-20260806020405289](https://github.com/user-attachments/assets/226dc6eb-8f2e-4af6-b715-a2970ca3b0e0) | ![image-20260806020341894](https://github.com/user-attachments/assets/dda9a6d4-f433-435d-b86a-3880c75be072) |
| 修复后 | ![image-20260806020748134](https://github.com/user-attachments/assets/3448684d-234f-4498-8ee4-ef8ae0a5cb76)<br />![image-20260806020815177](https://github.com/user-attachments/assets/e5c9c4b0-de14-4d61-a9c0-2638eab63185) | ![image-20260806020742121](https://github.com/user-attachments/assets/99bdf412-d313-438c-aa1d-c79fcb2c6fde) |



