### PR TITLE
fix: 支持 cron_strategy="cron" 的调度计算（每分钟全量备份 Bug）

### DIFF
--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -404,6 +404,9 @@ func (s *backupService) calculateNextRunTime(config *domain.BackupConfig) {
 		expr = "0 0 1 * *" // Midnight 1st of month
 	case "custom":
 		expr = config.CronExpression
+	case "cron":
+		// 前端保存自定义 cron 表达式时写入该策略值，与 custom 行为一致
+		expr = config.CronExpression
 	}
 
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)


### PR DESCRIPTION
## 问题

#455：前端保存自定义 cron 表达式时写入 `cron_strategy="cron"`，但 `calculateNextRunTime` 的 switch 缺少该 case：

- `expr` 保持空串 → `parser.Parse("")` 失败 → 函数直接 return，`NextRunTime` 保持零值
- 调度入口 `isScheduled := config.NextRunTime.Before(now)` 对零值恒为 `true` → **每次轮询（约每分钟）都执行一次全量备份**
- 实测：8 天积累约 10,000 个 zip / 4.7GB；日志每分钟报 `Failed to parse cron expression, expr:"", error:"empty spec string"`

## 修复

```go
case "cron":
    // 前端保存自定义 cron 表达式时写入该策略值，与 custom 行为一致
    expr = config.CronExpression
```

1 行修复，行为与 `custom` 一致。

## 验证

- `go build ./internal/service/` 通过，`gofmt` 无差异
- 生产环境（v3.6.0）实测：`UPDATE backup_config SET cron_strategy=custom` + 重启服务后，`NextRunTime` 正常计算为次日 05:43，备份停止每分钟执行（等价路径，已验证）

Fixes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)