### PR TITLE
fix: 重命名笔记时迁移 note_history 历史归属，修复重命名后历史版本丢失

### DIFF
--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -76,7 +76,7 @@ func initServices(cfg *AppConfig, infra *Infra, repos *Repositories, logger *zap
 	s.SyncLogService = service.NewSyncLogService(repos.SyncLogRepo, logger)
 
 	s.FolderService = service.NewFolderService(repos.FolderRepo, repos.NoteRepo, repos.FileRepo, s.VaultService, s.BackupService, s.GitSyncService, s.SyncLogService, infra.workerPool)
-	s.NoteService = service.NewNoteService(repos.UserRepo, repos.NoteRepo, repos.NoteLinkRepo, repos.FileRepo, repos.ShareRepo, s.VaultService, s.FolderService, s.BackupService, s.GitSyncService, s.SyncLogService, svcConfig)
+	s.NoteService = service.NewNoteService(repos.UserRepo, repos.NoteRepo, repos.NoteLinkRepo, repos.FileRepo, repos.ShareRepo, repos.NoteHistoryRepo, s.VaultService, s.FolderService, s.BackupService, s.GitSyncService, s.SyncLogService, svcConfig)
 	s.TokenService = service.NewTokenService(repos.AuthTokenRepo, repos.AuthTokenLogRepo, infra.TokenManager, logger, svcConfig.Token)
 	s.UserService = service.NewUserService(repos.UserRepo, infra.TokenManager, s.TokenService, logger, svcConfig)
 	s.OIDCService = service.NewOIDCService(repos.UserRepo, repos.OIDCIdentityRepo, s.TokenService)

--- a/internal/service/note_service.go
+++ b/internal/service/note_service.go
@@ -153,6 +153,7 @@ type noteService struct {
 	noteLinkRepo   domain.NoteLinkRepository  // Note link repository // 笔记链接仓库
 	fileRepo       domain.FileRepository      // File repository // 文件仓库
 	shareRepo      domain.UserShareRepository // Share repository for auto-revoke on delete // 分享仓库（删除时自动撤销）
+	historyRepo    domain.NoteHistoryRepository // Note history repository // 笔记历史仓库（rename 时迁移历史归属）
 	vaultService   VaultService               // Vault service // 仓库服务
 	folderService  FolderService              // Folder service // 文件夹服务
 	syncLogService SyncLogService             // Sync log service // 同步日志服务
@@ -169,13 +170,14 @@ type noteService struct {
 
 // NewNoteService creates NoteService instance
 // NewNoteService 创建 NoteService 实例
-func NewNoteService(userRepo domain.UserRepository, noteRepo domain.NoteRepository, noteLinkRepo domain.NoteLinkRepository, fileRepo domain.FileRepository, shareRepo domain.UserShareRepository, vaultSvc VaultService, folderSvc FolderService, backupSvc BackupService, gitSyncSvc GitSyncService, syncLogSvc SyncLogService, config *ServiceConfig) NoteService {
+func NewNoteService(userRepo domain.UserRepository, noteRepo domain.NoteRepository, noteLinkRepo domain.NoteLinkRepository, fileRepo domain.FileRepository, shareRepo domain.UserShareRepository, historyRepo domain.NoteHistoryRepository, vaultSvc VaultService, folderSvc FolderService, backupSvc BackupService, gitSyncSvc GitSyncService, syncLogSvc SyncLogService, config *ServiceConfig) NoteService {
 	return &noteService{
 		userRepo:       userRepo,
 		noteRepo:       noteRepo,
 		noteLinkRepo:   noteLinkRepo,
 		fileRepo:       fileRepo,
 		shareRepo:      shareRepo,
+		historyRepo:    historyRepo,
 		vaultService:   vaultSvc,
 		folderService:  folderSvc,
 		backupService:  backupSvc,
@@ -196,6 +198,7 @@ func (s *noteService) WithClient(clientType, name, version string) NoteService {
 		noteLinkRepo:   s.noteLinkRepo,
 		fileRepo:       s.fileRepo,
 		shareRepo:      s.shareRepo,
+		historyRepo:    s.historyRepo,
 		vaultService:   s.vaultService,
 		folderService:  s.folderService,
 		syncLogService: s.syncLogService,
@@ -1017,6 +1020,20 @@ func (s *noteService) Migrate(ctx context.Context, oldNoteID, newNoteID int64, u
 				zap.Int64("oldNoteID", oldNoteID),
 				zap.Int64("newNoteID", newNoteID),
 				zap.Error(shareErr))
+		}
+	}
+
+	// Migrate note history records: point all history versions of the old note ID to the new note ID
+	// Migrate note history records: point all history versions of the old note ID to the new note ID
+	// 迁移笔记历史记录：将旧笔记 ID 下的所有历史版本指向新笔记 ID
+	// （重命名前作者漏掉此迁移，导致重命名后历史版本丢失——回归修复）
+	if s.historyRepo != nil {
+		if err := s.historyRepo.Migrate(ctx, oldNoteID, newNoteID, uid); err != nil {
+			zap.L().Warn("Migrate: failed to migrate note history records",
+				zap.Int64(logger.FieldUID, uid),
+				zap.Int64("oldNoteID", oldNoteID),
+				zap.Int64("newNoteID", newNoteID),
+				zap.Error(err))
 		}
 	}
 

--- a/internal/service/note_service_test.go
+++ b/internal/service/note_service_test.go
@@ -1,0 +1,177 @@
+// Package service_test contains black-box tests for the service layer.
+// Package service_test 服务层的黑盒测试
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/haierkeys/fast-note-sync-service/internal/domain"
+	domainmocks "github.com/haierkeys/fast-note-sync-service/internal/domain/mocks"
+	"github.com/haierkeys/fast-note-sync-service/internal/dto"
+	"github.com/haierkeys/fast-note-sync-service/internal/service"
+	servicemocks "github.com/haierkeys/fast-note-sync-service/internal/service/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// 回归测试：重命名（Rename）必须迁移 note_history 表的历史归属
+// Regression: Rename must migrate note_history ownership from old note ID to new note ID
+//
+// 背景：noteService.Rename 会新建笔记记录（新 ID）并软删旧记录（Rename=1），
+// 所有挂在旧 ID 上的关联数据（snapshot/version/share）都已迁移，唯独 note_history
+// 表被遗漏，导致重命名后历史版本丢失。本次修复在 noteService.Migrate 中补充
+// historyRepo.Migrate 调用。以下测试防止该迁移再次被遗漏。
+// ---------------------------------------------------------------------------
+
+func oldNoteFixture() *domain.Note {
+	return &domain.Note{
+		ID:                      137,
+		VaultID:                 1,
+		Action:                  domain.NoteActionDelete,
+		Rename:                  1,
+		FID:                     10,
+		Path:                    "旧笔记.md",
+		PathHash:                "oldpathhash",
+		Content:                 "当前内容",
+		ContentHash:             "currenthash",
+		ContentLastSnapshot:     "上次快照",
+		ContentLastSnapshotHash: "snapshothash",
+		Version:                 5,
+		ClientName:              "obsidian",
+		ClientType:              "desktop",
+		ClientVersion:           "2.4.0",
+		Size:                    1024,
+		Ctime:                   1000,
+		Mtime:                   2000,
+		UpdatedTimestamp:        3000,
+	}
+}
+
+// newNoteSvc 构造 NoteService（vaultSvc/folderSvc 可为 nil，Migrate 级测试不需要它们）
+func newNoteSvc(t *testing.T, noteRepo *domainmocks.MockNoteRepository, historyRepo *domainmocks.MockNoteHistoryRepository, vaultSvc service.VaultService, folderSvc service.FolderService) service.NoteService {
+	t.Helper()
+	return service.NewNoteService(nil, noteRepo, nil, nil, nil, historyRepo, vaultSvc, folderSvc, nil, nil, nil, nil)
+}
+
+// TestNoteService_Migrate_MigratesNoteHistory 验证 Migrate 会把旧笔记 ID 的历史迁移到新笔记 ID。
+// 本次 bug 的直接回归测试：修复前 Migrate 从不调用 historyRepo.Migrate。
+func TestNoteService_Migrate_MigratesNoteHistory(t *testing.T) {
+	noteRepo := new(domainmocks.MockNoteRepository)
+	historyRepo := new(domainmocks.MockNoteHistoryRepository)
+
+	oldNote := oldNoteFixture()
+
+	noteRepo.On("GetByID", mock.Anything, int64(137), int64(1)).Return(oldNote, nil)
+	noteRepo.On("UpdateSnapshot", mock.Anything, oldNote.ContentLastSnapshot, oldNote.ContentLastSnapshotHash, oldNote.Version, int64(2048), int64(1)).Return(nil)
+	noteRepo.On("UpdateDelete", mock.Anything, mock.AnythingOfType("*domain.Note"), int64(1)).Return(nil)
+	// CountSizeSum 有 10 秒防抖 timer，测试窗口内不会触发，标记 Maybe
+	noteRepo.On("CountSizeSum", mock.Anything, int64(1), int64(1)).Return(&domain.CountSizeResult{Count: 1, Size: 1024}, nil).Maybe()
+	// 关键断言：历史迁移必须发生
+	historyRepo.On("Migrate", mock.Anything, int64(137), int64(2048), int64(1)).Return(nil)
+
+	svc := newNoteSvc(t, noteRepo, historyRepo, nil, nil)
+
+	err := svc.Migrate(context.Background(), 137, 2048, 1)
+	require.NoError(t, err)
+
+	historyRepo.AssertCalled(t, "Migrate", mock.Anything, int64(137), int64(2048), int64(1))
+	noteRepo.AssertCalled(t, "UpdateSnapshot", mock.Anything, oldNote.ContentLastSnapshot, oldNote.ContentLastSnapshotHash, oldNote.Version, int64(2048), int64(1))
+	noteRepo.AssertCalled(t, "UpdateDelete", mock.Anything, mock.AnythingOfType("*domain.Note"), int64(1))
+	historyRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+}
+
+// TestNoteService_Migrate_HistoryErrorWarnNotFail 验证历史迁移失败只告警、不阻断整个迁移流程
+//（与 share 迁移失败的处理保持一致）。
+func TestNoteService_Migrate_HistoryErrorWarnNotFail(t *testing.T) {
+	noteRepo := new(domainmocks.MockNoteRepository)
+	historyRepo := new(domainmocks.MockNoteHistoryRepository)
+
+	oldNote := oldNoteFixture()
+
+	noteRepo.On("GetByID", mock.Anything, int64(137), int64(1)).Return(oldNote, nil)
+	noteRepo.On("UpdateSnapshot", mock.Anything, oldNote.ContentLastSnapshot, oldNote.ContentLastSnapshotHash, oldNote.Version, int64(2048), int64(1)).Return(nil)
+	noteRepo.On("UpdateDelete", mock.Anything, mock.AnythingOfType("*domain.Note"), int64(1)).Return(nil)
+	noteRepo.On("CountSizeSum", mock.Anything, int64(1), int64(1)).Return(&domain.CountSizeResult{Count: 1, Size: 1024}, nil)
+	historyRepo.On("Migrate", mock.Anything, int64(137), int64(2048), int64(1)).Return(assert.AnError)
+
+	svc := newNoteSvc(t, noteRepo, historyRepo, nil, nil)
+
+	err := svc.Migrate(context.Background(), 137, 2048, 1)
+	require.NoError(t, err)
+	historyRepo.AssertCalled(t, "Migrate", mock.Anything, int64(137), int64(2048), int64(1))
+}
+
+// TestNoteService_Rename_MigratesNoteHistory 端到端回归：Rename 完成后，
+// 后台 Migrate 必须把旧笔记 ID 的历史迁移到新笔记 ID（异步，用 Eventually 等待）。
+func TestNoteService_Rename_MigratesNoteHistory(t *testing.T) {
+	noteRepo := new(domainmocks.MockNoteRepository)
+	historyRepo := new(domainmocks.MockNoteHistoryRepository)
+	vaultSvc := new(servicemocks.MockVaultService)
+	folderSvc := new(servicemocks.MockFolderService)
+
+	oldNote := oldNoteFixture()
+	newNote := &domain.Note{
+		ID:          2048,
+		VaultID:     1,
+		Action:      domain.NoteActionCreate,
+		Path:        "新笔记.md",
+		PathHash:    "newpathhash",
+		FID:         10,
+		Content:     oldNote.Content,
+		ContentHash: oldNote.ContentHash,
+		Version:     oldNote.Version,
+		Ctime:       oldNote.Ctime,
+		Mtime:       oldNote.Mtime,
+	}
+
+	// Rename 主流程依赖
+	vaultSvc.On("MustGetID", mock.Anything, int64(1), "obsidian-vault").Return(int64(1), nil)
+	noteRepo.On("GetAllByPathHash", mock.Anything, "newpathhash", int64(1), int64(1)).Return(nil, nil)
+	noteRepo.On("GetByPathHash", mock.Anything, "oldpathhash", int64(1), int64(1)).Return(oldNote, nil)
+	noteRepo.On("Update", mock.Anything, mock.AnythingOfType("*domain.Note"), int64(1)).Return(oldNote, nil)
+	folderSvc.On("EnsurePathFID", mock.Anything, int64(1), int64(1), "").Return(int64(10), nil)
+	noteRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.Note"), int64(1)).Return(newNote, nil)
+	folderSvc.On("SyncResourceFID", mock.Anything, int64(1), int64(1), mock.Anything, mock.Anything).Return(nil)
+	folderSvc.On("CleanupEmptyAncestors", mock.Anything, int64(1), int64(1), "旧笔记.md").Return(nil)
+
+	// Migrate goroutine 依赖
+	noteRepo.On("GetByID", mock.Anything, int64(137), int64(1)).Return(oldNote, nil)
+	noteRepo.On("UpdateSnapshot", mock.Anything, oldNote.ContentLastSnapshot, oldNote.ContentLastSnapshotHash, oldNote.Version, int64(2048), int64(1)).Return(nil)
+	noteRepo.On("UpdateDelete", mock.Anything, mock.AnythingOfType("*domain.Note"), int64(1)).Return(nil)
+	noteRepo.On("CountSizeSum", mock.Anything, int64(1), int64(1)).Return(&domain.CountSizeResult{Count: 1, Size: 1024}, nil).Maybe()
+	historyRepo.On("Migrate", mock.Anything, int64(137), int64(2048), int64(1)).Return(nil)
+
+	svc := newNoteSvc(t, noteRepo, historyRepo, vaultSvc, folderSvc)
+
+	_, _, err := svc.Rename(context.Background(), 1, &dto.NoteRenameRequest{
+		Vault:       "obsidian-vault",
+		Path:        "新笔记.md",
+		PathHash:    "newpathhash",
+		OldPath:     "旧笔记.md",
+		OldPathHash: "oldpathhash",
+	})
+	require.NoError(t, err)
+
+	// Rename 内部 go s.Migrate(...) 异步执行，等待 history 迁移被触发
+	deadline := time.Now().Add(2 * time.Second)
+	migrated := false
+	for time.Now().Before(deadline) {
+		if len(historyRepo.Calls) > 0 {
+			migrated = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.True(t, migrated, "Rename 后应触发 note_history 迁移（oldNoteID 137 -> newNoteID 2048）")
+	historyRepo.AssertCalled(t, "Migrate", mock.Anything, int64(137), int64(2048), int64(1))
+
+	// 确认 Rename 主流程 stub 全部命中
+	noteRepo.AssertExpectations(t)
+	vaultSvc.AssertExpectations(t)
+	folderSvc.AssertExpectations(t)
+}


### PR DESCRIPTION
fix: 重命名笔记时迁移 note_history 历史归属，修复重命名后历史版本丢失

## 问题描述

Obsidian 中重命名 `.md` 文件后，右键「历史版本」看不到旧路径的历史记录——新文件像全新笔记一样没有历史。其他端同步后同样如此。

## 根因

`noteService.Rename`（internal/service/note_service.go:650）的处理方式是**新建笔记记录（新 ID）并软删旧记录（`Rename=1`）**，所有挂在旧 ID 上的关联数据都需要迁移：

- ✅ note 表 `ContentLastSnapshot`/`Version` —— `go s.Migrate(...)` 已迁移
- ✅ `user_share` 表 `res_id` —— `MigrateResID` 已迁移（PR #195）
- ❌ **`note_history` 表 `note_id` —— 从未迁移**

history 迁移的完整机制**已存在但从未被触发**：`NoteHistoryTask`（internal/task/task_note_history.go:49-50）消费 `NoteMigrateChannel` 后调用 `NoteHistoryService.Migrate`（`UPDATE note_history SET note_id = new WHERE note_id = old`），但该 channel 的唯一生产者 `MigratePush` 在生产代码中**零调用**（grep 全库仅接口声明一处，属死代码）。因此重命名后历史记录永远停留在旧笔记 ID 下，新路径按 `path → noteID → ListByNoteID` 查询不到任何历史。

## 修复方案（方案 B）

给 `noteService` 注入 `NoteHistoryRepository`，在 `noteService.Migrate` 中补充 `historyRepo.Migrate`（一条 UPDATE 迁移 note_history 归属），随 Rename 的 `go s.Migrate(...)` 异步执行；迁移失败仅告警不阻断（与 share 迁移失败处理保持一致）。

## 改动

- `internal/service/note_service.go`：`noteService` 新增 `historyRepo` 字段；`NewNoteService` 新增参数；`WithClient` 透传；`Migrate` 中补充 note_history 表迁移
- `internal/app/services.go`：`NewNoteService` 装配传入 `repos.NoteHistoryRepo`（该 repo 本已注册，零新增依赖）
- `internal/service/note_service_test.go`：新增 3 个回归测试——Migrate 触发历史迁移 / 历史迁移失败不阻断 / Rename 端到端触发历史迁移（异步等待）

## 测试

`go test ./internal/service/ ./internal/app/` 全部通过。

## 兼容性

无 API/协议/消息格式变化，客户端无需升级，旧版本服务端升级后行为即修复。历史数据的存量修复（已丢历史重建映射）在部署侧完成，不属于本 PR 代码变更。
