### PR TITLE
Support ChatGPT connectors through OpenAI Secure MCP Tunnel

### DIFF
--- a/internal/middleware/404nofound.go
+++ b/internal/middleware/404nofound.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net/http"
+
 	"github.com/haierkeys/fast-note-sync-service/pkg/app"
 	"github.com/haierkeys/fast-note-sync-service/pkg/code"
 
@@ -11,8 +13,13 @@ import (
 // NoFound 404 处理
 func NoFound() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		response := app.NewResponse(c)
-		response.ToResponse(code.ErrorNotFoundAPI)
-		c.Abort()
+		codeObj := code.ErrorNotFoundAPI
+		c.Set("status_code", http.StatusNotFound)
+		c.AbortWithStatusJSON(http.StatusNotFound, app.Res{
+			Code:    codeObj.Code(),
+			Status:  codeObj.Status(),
+			Message: codeObj.MsgIn(c.GetString("lang")),
+			Data:    codeObj.Data(),
+		})
 	}
 }

--- a/internal/middleware/404nofound_test.go
+++ b/internal/middleware/404nofound_test.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/haierkeys/fast-note-sync-service/pkg/app"
+	"github.com/haierkeys/fast-note-sync-service/pkg/code"
+)
+
+func TestNoFoundReturnsHTTPNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.NoRoute(NoFound())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/missing-route", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body=%s", w.Code, w.Body.String())
+	}
+
+	var body app.Res
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if body.Code != code.ErrorNotFoundAPI.Code() {
+		t.Fatalf("code = %d, want %d", body.Code, code.ErrorNotFoundAPI.Code())
+	}
+	if body.Status {
+		t.Fatal("status = true, want false")
+	}
+}

--- a/internal/routers/mcp_router/tool_metadata.go
+++ b/internal/routers/mcp_router/tool_metadata.go
@@ -32,11 +32,16 @@ func withMCPToolMetadata(tool mcp.Tool, cfg *app.AppConfig, metadata mcpToolMeta
 	if tool.Meta.AdditionalFields == nil {
 		tool.Meta.AdditionalFields = make(map[string]any)
 	}
-	tool.Meta.AdditionalFields["securitySchemes"] = []map[string]any{
-		{
-			"type":   "oauth2",
-			"scopes": oauthScopesForTool(cfg, metadata.Scopes),
-		},
+
+	if cfg != nil && cfg.OAuth.Enabled {
+		tool.Meta.AdditionalFields["securitySchemes"] = []map[string]any{
+			{
+				"type":   "oauth2",
+				"scopes": oauthScopesForTool(cfg, metadata.Scopes),
+			},
+		}
+	} else {
+		delete(tool.Meta.AdditionalFields, "securitySchemes")
 	}
 
 	return tool

--- a/internal/routers/mcp_router/tool_metadata_test.go
+++ b/internal/routers/mcp_router/tool_metadata_test.go
@@ -189,3 +189,34 @@ func TestToolMetadataDefaultFNSScopeOmitsOAuthScopes(t *testing.T) {
 		t.Fatalf("scopes = %#v, want empty", got)
 	}
 }
+
+func TestToolMetadataOmitsSecuritySchemesWhenOAuthDisabled(t *testing.T) {
+	cfg := &appconfig.AppConfig{
+		OAuth: config.OAuthConfig{Enabled: false},
+	}
+
+	tool := withMCPToolMetadata(mcp.NewTool("note_get"), cfg, mcpToolMetadata{
+		ReadOnly: true,
+		Scopes:   []string{"notes:read"},
+	})
+
+	payload, err := json.Marshal(mcp.NewListToolsResult([]mcp.Tool{tool}, ""))
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var body struct {
+		Tools []struct {
+			Meta map[string]any `json:"_meta"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(body.Tools) != 1 {
+		t.Fatalf("tools length = %d, want 1", len(body.Tools))
+	}
+	if _, ok := body.Tools[0].Meta["securitySchemes"]; ok {
+		t.Fatalf("securitySchemes should be omitted when OAuth is disabled: %#v", body.Tools[0].Meta)
+	}
+}

--- a/internal/routers/router_oauth_metadata_test.go
+++ b/internal/routers/router_oauth_metadata_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/haierkeys/fast-note-sync-service/internal/config"
+	"github.com/haierkeys/fast-note-sync-service/internal/middleware"
 )
 
 func TestOAuthMetadataRoutes_Output(t *testing.T) {
@@ -104,6 +105,7 @@ func TestOAuthMetadataRoutes_Disabled(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	r := gin.New()
+	r.NoRoute(middleware.NoFound())
 	registerOAuthMetadataRoutesWithConfig(r, config.OAuthConfig{})
 
 	w := httptest.NewRecorder()


### PR DESCRIPTION
This PR fixes MCP authentication discovery when Fast Note Sync is used with a ChatGPT custom connector through OpenAI Secure MCP Tunnel.

With OAuth disabled, FNS currently:

- advertises MCP tools as `oauth2`
- returns HTTP 200 for missing OAuth/OIDC discovery routes

This causes ChatGPT connector setup with `No Auth` to fail because the MCP server appears to have an invalid/mixed auth configuration.

The fix in this PR consists of:

- Only advertise OAuth2 tool metadata when OAuth is enabled.
- Return HTTP 404 for unmatched routes instead of HTTP 200 with a `Not Found API` payload.
- Add regression tests for both behaviors.

The 404 change is made in the generic `NoRoute` handler rather than special-casing OAuth discovery paths, so all nonexistent routes get the correct HTTP status while valid FNS API errors keep their existing behavior.

I have tried this change locally with my setup and it worked.